### PR TITLE
Recent PR bug fixes

### DIFF
--- a/Src/utils.js
+++ b/Src/utils.js
@@ -5,7 +5,7 @@ const {
   existsSync,
   appendFileSync,
   writeFileSync,
-  statSync,
+  statfsSync,
 } = require("fs");
 const moment = require("moment");
 const chalk = require("chalk");
@@ -48,13 +48,9 @@ console.warn = function (...args) {
 
 // If a file is not writing, check the disk space.
 const checkDiskSpace = async (directory) => {
-  statSync(directory, (error, stats) => {
-    if (error) {
-      console.error("Error:", error);
-      return;
-    }
-
-    const availableSpaceMB = (stats["blksize"] * stats["blocks"]) / 1024 / 1024;
+  try {
+    const stats = statfsSync(directory);
+    const availableSpaceMB = (stats.bavail * stats.bsize) / 1024 / 1024;
 
     if (availableSpaceMB >= 50) {
       console.log("There is at least 50 megabytes of disk space available.");
@@ -63,9 +59,12 @@ const checkDiskSpace = async (directory) => {
       setTimeout(() => {
         checkDiskSpace(directory);
       }, 5000);
-      checkDiskSpace(directory);
     }
-  });
+    return availableSpaceMB;
+  } catch (error) {
+    console.error("Error checking disk space:", error);
+    throw error;
+  }
 };
 
 // If a file fails to read or write, check if it is busy.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fix `checkDiskSpace` to correctly measure and report free disk space.

The previous implementation using `statSync` was effectively a no-op, always logging `logCount 0`, and contained an immediate recursive call that prevented the check from completing successfully. This change switches to `fs.statfsSync` for accurate free-space measurement and ensures the check runs as intended.

---
<p><a href="https://cursor.com/agents/bc-233da45d-a453-483d-a9e4-19fbb07f5345"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-233da45d-a453-483d-a9e4-19fbb07f5345"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->